### PR TITLE
TemplateData in match method shouldnt be required as original version's way

### DIFF
--- a/source/i18n.ts
+++ b/source/i18n.ts
@@ -167,7 +167,7 @@ function compileTemplates(root: Readonly<Record<string, string>>): RepositoryEnt
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
 
 export function match(resourceKey: string, templateData?: Readonly<TemplateData>): (text: string, ctx: TelegrafContextWithI18n) => string[] | null {
-  return (text, ctx) => (text && ctx?.i18n && text === ctx.i18n.t(resourceKey, templateData || {})) ? [text] : null
+  return (text, ctx) => (text && ctx?.i18n && text === ctx.i18n.t(resourceKey, templateData)) ? [text] : null
 }
 
 export function reply(resourceKey: string, extra?: ExtraReplyMessage): (ctx: TelegrafContextWithI18n) => Promise<Message> {

--- a/source/i18n.ts
+++ b/source/i18n.ts
@@ -166,8 +166,8 @@ function compileTemplates(root: Readonly<Record<string, string>>): RepositoryEnt
 
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
 
-export function match(resourceKey: string, templateData: Readonly<TemplateData>): (text: string, ctx: TelegrafContextWithI18n) => string[] | null {
-  return (text, ctx) => (text && ctx?.i18n && text === ctx.i18n.t(resourceKey, templateData)) ? [text] : null
+export function match(resourceKey: string, templateData?: Readonly<TemplateData>): (text: string, ctx: TelegrafContextWithI18n) => string[] | null {
+  return (text, ctx) => (text && ctx?.i18n && text === ctx.i18n.t(resourceKey, templateData || {})) ? [text] : null
 }
 
 export function reply(resourceKey: string, extra?: ExtraReplyMessage): (ctx: TelegrafContextWithI18n) => Promise<Message> {


### PR DESCRIPTION
I found your module very useful and add one tune from myself: as in original version match has to have 1 required parameter and 1 optional, for compatibility reasons.
I fix this way, pls review.